### PR TITLE
Switch to floating point RGBA pixels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # pxl
 
-A simple game framework in Rust.
+A simple framework for making games in Rust.

--- a/examples/life/src/main.rs
+++ b/examples/life/src/main.rs
@@ -88,13 +88,15 @@ impl Program for Life {
       *pixel = match cell {
         Alive => Pixel {
           red:   random(),
-          green: 0,
+          green: 0.0,
           blue:  random(),
+          alpha: 1.0,
         },
         Dead => Pixel {
-          red:   0,
-          green: 0,
-          blue:  0,
+          red:   0.0,
+          green: 0.0,
+          blue:  0.0,
+          alpha: 1.0,
         },
       };
     }

--- a/src/fragment_shader.glsl
+++ b/src/fragment_shader.glsl
@@ -6,5 +6,5 @@ out vec4 color;
 uniform sampler2D pixels;
 
 void main() {
-  color = vec4(texture(pixels, uv).rgb, 1.0);
+  color = texture(pixels, uv);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,9 +5,10 @@ pub const SAMPLES_PER_SECOND: u32 = 48_000;
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 pub struct Pixel {
-  pub red: u8,
-  pub green: u8,
-  pub blue: u8,
+  pub red: f32,
+  pub green: f32,
+  pub blue: f32,
+  pub alpha: f32,
 }
 
 #[repr(C)]

--- a/src/runtime/display.rs
+++ b/src/runtime/display.rs
@@ -99,12 +99,12 @@ impl Display {
       gl::TexImage2D(
         gl::TEXTURE_2D,
         0,
-        gl::RGB as i32,
+        gl::RGBA32F as i32,
         self.dimensions.0 as i32,
         self.dimensions.1 as i32,
         0,
-        gl::RGB,
-        gl::UNSIGNED_BYTE,
+        gl::RGBA,
+        gl::FLOAT,
         bytes,
       );
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -58,9 +58,10 @@ impl Runtime {
 
     let pixels = vec![
       Pixel {
-        red: 0,
-        green: 255,
-        blue: 0
+        red: 0.0,
+        green: 1.0,
+        blue: 0.0,
+        alpha: 1.0,
       };
       dimensions.0 * dimensions.1
     ];


### PR DESCRIPTION
Switched from RGB byte pixels because:

- Expression colors as between 0.0 and 1.0 is more intuitive than 0 to 255
- Floating point textures will allow for much more powerful custom fragment shaders
- When we eventually add image loading, we'll want to support images with transparency, such as PNGs. This will allow us to use the same pixel format in both images and rendering.