### PR TITLE
Add Synthesizer trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ pub trait Synthesizer: Send + 'static {
   fn synthesize(&mut self, _samples_played: u64, _buffer: &mut [Sample]) {}
 }
 
-pub trait Program: Send + 'static {
+pub trait Program: 'static {
   /// Initialize a new Program object
   fn new() -> Self
   where
@@ -119,11 +119,10 @@ pub trait Program: Send + 'static {
 
 pub fn run<P: Program>() -> ! {
   use runtime::Runtime;
-  use std::{process,
-            sync::{Arc, Mutex}};
+  use std::process;
 
   let program = P::new();
-  let result = Runtime::new(Arc::new(Mutex::new(program))).and_then(|runtime| runtime.run());
+  let result = Runtime::new(Box::new(program)).and_then(|runtime| runtime.run());
 
   if let Err(error) = result {
     eprintln!("{}", error);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,14 @@ pub trait Program: 'static {
   fn render(&mut self, _pixels: &mut [Pixel]) {}
 
   /// The program's synthesizer
+  ///
+  /// Will be called by the runtime during initialization. If it returns
+  /// Some, the contained Synthesizer will be moved to a dedicated audio
+  /// thread and called periodically to produce samples for the outgoing
+  /// audio stream.
+  ///
+  /// In order to prevent buffer underruns, avoid locking the `Mutex`
+  /// containing the Synthesizer for long periods of time.
   fn synthesizer(&self) -> Option<Arc<Mutex<Synthesizer>>> {
     None
   }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -10,7 +10,6 @@ use std::{ffi::CString,
           mem,
           ptr,
           str,
-          sync::{Arc, Mutex},
           thread};
 
 use super::*;
@@ -31,7 +30,7 @@ pub struct Runtime {
   events: Vec<Event>,
   window_event_loop: glutin::EventsLoop,
   pixels: Vec<Pixel>,
-  program: Arc<Mutex<Program>>,
+  program: Box<Program>,
   should_quit: bool,
   gl_window: GlWindow,
   current_title: String,
@@ -39,18 +38,12 @@ pub struct Runtime {
 }
 
 impl Runtime {
-  pub fn new(program: Arc<Mutex<Program>>) -> Result<Runtime, Error> {
+  pub fn new(program: Box<Program>) -> Result<Runtime, Error> {
     let window_event_loop = glutin::EventsLoop::new();
 
-    let current_title;
-    let dimensions;
-    let synthesizer;
-    {
-      let program = program.lock().unwrap();
-      current_title = program.title().to_string();
-      dimensions = program.dimensions();
-      synthesizer = program.synthesizer();
-    }
+    let current_title = program.title().to_string();
+    let dimensions = program.dimensions();
+    let synthesizer = program.synthesizer();
 
     let window = glutin::WindowBuilder::new()
       .with_title(current_title.as_str())
@@ -132,33 +125,24 @@ impl Runtime {
         self.gl_window.resize(w, h);
       }
 
-      // We try to avoid doing any work while holding the lock to give the
-      // audio callback a chance to obtain the lock.
+      self.program.tick(&self.events);
 
-      self.program.lock().unwrap().tick(&self.events);
-
-      let dimensions = self.program.lock().unwrap().dimensions();
+      let dimensions = self.program.dimensions();
 
       let pixel_count = dimensions.0 * dimensions.1;
       if self.pixels.len() != pixel_count {
         self.pixels.resize(pixel_count, DEFAULT_PIXEL);
       }
 
-      {
-        let program = self.program.lock().unwrap();
-        self.display.set_shaders(program.vertex_shader(), program.fragment_shader())?;
-      }
+      self.display.set_shaders(self.program.vertex_shader(), self.program.fragment_shader())?;
 
-      {
-        let mut program = self.program.lock().unwrap();
-        program.render(&mut self.pixels);
-        self.should_quit = program.should_quit() | should_quit;
-        let title = program.title();
-        if title != self.current_title {
-          self.gl_window.set_title(title);
-          self.current_title.clear();
-          self.current_title.push_str(&title);
-        }
+      self.program.render(&mut self.pixels);
+      self.should_quit = self.program.should_quit() | should_quit;
+      let title = self.program.title();
+      if title != self.current_title {
+        self.gl_window.set_title(title);
+        self.current_title.clear();
+        self.current_title.push_str(&title);
       }
 
       self.display.present(&self.pixels, dimensions);

--- a/src/runtime/speaker.rs
+++ b/src/runtime/speaker.rs
@@ -3,17 +3,19 @@ use std::sync::{Arc, Mutex};
 use {runtime::{cpal::{self, EventLoop, Format, SampleFormat, SampleRate, StreamData,
                       UnknownTypeOutputBuffer},
                error::Error},
-     Program,
+
+     Synthesizer,
      Sample,
      SAMPLES_PER_SECOND};
 
+
 pub struct Speaker {
-  program: Arc<Mutex<Program>>,
+  synthesizer: Arc<Mutex<Synthesizer>>,
   event_loop: EventLoop,
 }
 
 impl Speaker {
-  pub fn new(program: Arc<Mutex<Program>>) -> Result<Speaker, Error> {
+  pub fn new(synthesizer: Arc<Mutex<Synthesizer>>) -> Result<Speaker, Error> {
     let event_loop = EventLoop::new();
 
     let device = cpal::default_output_device().ok_or(Error::AudioOutputDeviceInitialization)?;
@@ -29,13 +31,13 @@ impl Speaker {
     event_loop.play_stream(stream_id);
 
     Ok(Speaker {
-      program,
+      synthesizer,
       event_loop,
     })
   }
 
   pub fn play(self) -> ! {
-    let program = self.program;
+    let synthesizer = self.synthesizer;
     let event_loop = self.event_loop;
     let mut samples = Vec::new();
     let mut samples_played = 0;
@@ -51,7 +53,7 @@ impl Speaker {
             right: 0.0,
           },
         );
-        program
+        synthesizer
           .lock()
           .unwrap()
           .synthesize(samples_played, &mut samples);


### PR DESCRIPTION
Adds the `Synthesizer` trait. A program may now optionally return a Synthesizer object that is responsible for generating audio.

This complicates the API, but allows the rendering/simulation thread and the audio thread to be more loosely coupled. Before, the rendering and simulation thread contended for a single Mutex protecting the program. Now, the program returns a discrete Synthesizer object that it shares with the rendering thread. Updates to the Synthesizer object to change playing audio can then be made briefly enough to avoid starving the outgoing audio buffer.

@soenkehahn, what do you think of this? This PR contains an update to the life example that uses the API to play a tone whose intensity is based on the number of cells that are alive.

Fixes #53 

Edit: Also allows the program lock and `Send` bound on `Program` to be removed.