### PR TITLE
Support all sample formats by converting from f32

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,9 +46,9 @@ pub trait Synthesizer: Send + 'static {
   ///
   /// Called by the runtime as needed to fill the outgoing audio buffer
   ///
-  /// * `played`  — number of samples written by previous calls to synthesize
-  /// * `buffer`  — an array of audio samples
-  fn synthesize(&mut self, _samples_played: u64, _buffer: &mut [Sample]) {}
+  /// * `samples_played` — number of samples written by previous calls to synthesize
+  /// * `output_buffer`  — the audio samples that synthesize should write
+  fn synthesize(&mut self, _samples_played: u64, _output_buffer: &mut [Sample]) {}
 }
 
 pub trait Program: 'static {

--- a/src/runtime/error.rs
+++ b/src/runtime/error.rs
@@ -4,6 +4,7 @@ use std::fmt::{self, Display, Formatter};
 
 pub enum Error {
   AudioOutputDeviceInitialization,
+  AudioOutputDoesNotSupport48khzSampleRate,
   WindowCreation {
     creation_error: glutin::CreationError,
   },
@@ -38,6 +39,7 @@ impl Display for Error {
     use self::Error::*;
     match self {
       AudioOutputDeviceInitialization => write!(f, "Failed to initialize audio output device."),
+      AudioOutputDoesNotSupport48khzSampleRate => write!(f, "Audio output device does not support 48khz sample rate"),
       WindowCreation { creation_error } => write!(f, "Failed to create window: {}", creation_error),
       GraphicsContext { context_error } => {
         write!(f, "OpenGL graphics context errror: {}", context_error)


### PR DESCRIPTION
Allows us to support audio hardware without native f32 support.

Fixes #57