### PR TITLE
Mention release mode in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,15 @@
 
 A simple framework for making games in Rust.
 
-### Dependencies
+## Building
 
-On Ubuntu, install this dependency before building.
+Since `pxl` programs use per-pixel rendering, building in release mode can yield dramatically improved performance. Do `cargo run --release` to build in release mode.
+
+## Dependencies
+
+The `pxl` runtime plays audio using `cpal`, which requires ALSA headers/libraries on Linux;
+
+On Ubuntu, you can install them with:
 
 ```sh
 sudo apt install libasound2-dev


### PR DESCRIPTION
Since pxl uses per-pixel rendering, building in release mode can be necessary to achieve acceptable performance. Mention this in the readme.