### PR TITLE
Handle high DPI displays correctly

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,5 +1,5 @@
-# run all tests
-default: test
+# default to `watch`
+default: watch
 
 # submit a pull request
 pr: fmt clippy test
@@ -20,6 +20,7 @@ test:
 fmt:
 	cargo fmt
 
+# watch for changes and run `cargo fmt` and `cargo check`
 watch:
 	cargo watch --clear --exec fmt --exec check
 

--- a/pxl/Cargo.toml
+++ b/pxl/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/pxl"
 [dependencies]
 cpal   = "0.8.1"
 gl     = "0.10.0"
-glutin = "0.16.0"
+glutin = "0.17.0"
 
 [dev-dependencies]
 rand = "0.5.0"

--- a/pxl/examples/blaster.rs
+++ b/pxl/examples/blaster.rs
@@ -9,7 +9,7 @@ impl Program for Blaster {
     Blaster {}
   }
 
-  fn dimensions(&self) -> (usize, usize) {
+  fn resolution(&self) -> (usize, usize) {
     (256, 256)
   }
 

--- a/pxl/examples/life.rs
+++ b/pxl/examples/life.rs
@@ -122,7 +122,7 @@ impl Program for Life {
     }
   }
 
-  fn dimensions(&self) -> (usize, usize) {
+  fn resolution(&self) -> (usize, usize) {
     (WIDTH, HEIGHT)
   }
 

--- a/pxl/examples/shaders/main.rs
+++ b/pxl/examples/shaders/main.rs
@@ -7,8 +7,8 @@ use fragment_shaders::FRAGMENT_SHADERS;
 use pxl::*;
 use vertex_shaders::VERTEX_SHADERS;
 
-const WIDTH: usize = 768;
-const HEIGHT: usize = 768;
+const WIDTH: usize = 512;
+const HEIGHT: usize = 512;
 
 const WHITE: Pixel = Pixel {
   red: 1.0,
@@ -41,7 +41,7 @@ impl Program for Shaders {
     "pxl shaders"
   }
 
-  fn dimensions(&self) -> (usize, usize) {
+  fn resolution(&self) -> (usize, usize) {
     (WIDTH, HEIGHT)
   }
 

--- a/pxl/src/lib.rs
+++ b/pxl/src/lib.rs
@@ -172,14 +172,14 @@ pub trait Program: 'static {
   where
     Self: Sized;
 
-  /// Return the desired width and height of pixel surface
+  /// Return the desired resolution of the pixel surface.
   ///
   /// Will be called immediately before calling `render()`.
   /// Determines the length of the pixel slice passed to
   /// `render()`. If (256, 256) is returned, the pixel
   /// slice passed to `render()` will contain 256 * 256,
   /// elements.
-  fn dimensions(&self) -> (usize, usize);
+  fn resolution(&self) -> (usize, usize);
 
   /// Return the vertex shader to be used in the runtime's
   /// rendering pipeline
@@ -241,8 +241,8 @@ pub trait Program: 'static {
   ///
   /// Called by the runtime whenever the display is ready to present a new frame
   ///
-  /// WIDTH  — first element of the tuple returned by `dimensions()`
-  /// HEIGHT — second element of the tuple returned by `dimensions()`
+  /// WIDTH  — first element of the tuple returned by `resolution()`
+  /// HEIGHT — second element of the tuple returned by `resolution()`
   ///
   /// * `pixels` — a slice of pixels with `WIDTH * HEIGHT` elements
   ///              `pixels[x + y * WIDTH]` is the `x`th pixel in the
@@ -290,8 +290,8 @@ pub trait Program: 'static {
 ///     AwesomeProgram{}
 ///   }
 ///
-///   // Set the dimensions of the window
-///   fn dimensions(&self) -> (usize, usize) {
+///   // Set the resolution of the pixel surface
+///   fn resolution(&self) -> (usize, usize) {
 ///     (256, 256)
 ///   }
 /// }

--- a/pxl/src/runtime/common.rs
+++ b/pxl/src/runtime/common.rs
@@ -9,6 +9,9 @@ pub use runtime::{
   cpal::{
     EventLoop, Format, Sample, SampleRate, StreamData, SupportedFormat, UnknownTypeOutputBuffer,
   },
-  display::Display, error::Error, gl::types::*, glutin::{GlContext, GlWindow},
+  display::Display, error::Error, gl::types::*,
+  glutin::{
+    dpi::{LogicalSize, PhysicalSize}, GlContext, GlWindow,
+  },
   shader_cache::ShaderCache, speaker::Speaker,
 };

--- a/pxl/src/runtime/display.rs
+++ b/pxl/src/runtime/display.rs
@@ -133,7 +133,7 @@ impl Display {
     Ok(())
   }
 
-  pub fn present(&mut self, pixels: &[Pixel], dimensions: (usize, usize), window_size: (u32, u32)) {
+  pub fn present(&mut self, pixels: &[Pixel], resolution: (usize, usize), window_size: (u32, u32)) {
     let pixels = pixels.as_ptr();
     let bytes = pixels as *const c_void;
 
@@ -163,8 +163,8 @@ impl Display {
           gl::TEXTURE_2D,
           0,
           gl::RGBA32F as i32,
-          dimensions.0 as i32,
-          dimensions.1 as i32,
+          resolution.0 as i32,
+          resolution.1 as i32,
           0,
           gl::RGBA,
           gl::FLOAT,
@@ -178,8 +178,8 @@ impl Display {
             gl::TEXTURE_2D,
             0,
             gl::RGBA32F as i32,
-            dimensions.0 as i32,
-            dimensions.1 as i32,
+            resolution.0 as i32,
+            resolution.1 as i32,
             0,
             gl::RGBA,
             gl::FLOAT,
@@ -199,7 +199,7 @@ impl Display {
         }
 
         gl::Clear(gl::COLOR_BUFFER_BIT);
-        gl::Viewport(0, 0, dimensions.0 as i32, dimensions.1 as i32);
+        gl::Viewport(0, 0, resolution.0 as i32, resolution.1 as i32);
         gl::DrawArrays(gl::TRIANGLES, 0, 6);
       }
 


### PR DESCRIPTION
- Updates glutin to 0.17.0, which supports high DPI displays

- Changes `Program::dimensions` to `Program::resolution`, to better reflect that it is used to size the pixel buffer passed to render, which is independent of the window size

- Increase the size of the initial window if the monitor size allows it