### PR TITLE
Allow shaders to access FFT of audio output

### DIFF
--- a/justfile
+++ b/justfile
@@ -22,7 +22,7 @@ test:
 
 # format rust sourcecode with rustfmt
 fmt:
-	cargo fmt
+	cargo fmt --all
 
 # watch for changes and run `cargo fmt` and `cargo check`
 watch:
@@ -38,7 +38,7 @@ outdated:
 
 # build and open docs
 doc:
-	cargo doc --open
+	cargo doc --open -p pxl
 
 # everyone's favorite animate paper clip
 clippy:

--- a/pxl-mono/src/main.rs
+++ b/pxl-mono/src/main.rs
@@ -22,8 +22,18 @@ struct Loopback {
 }
 
 const USE_LOOPBACK_DEVICE: bool = true;
-const BLACK: Pixel = Pixel{red: 0.0, green: 0.0, blue: 0.0, alpha: 1.0};
-const WHITE: Pixel = Pixel{red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0};
+const BLACK: Pixel = Pixel {
+  red: 0.0,
+  green: 0.0,
+  blue: 0.0,
+  alpha: 1.0,
+};
+const WHITE: Pixel = Pixel {
+  red: 1.0,
+  green: 1.0,
+  blue: 1.0,
+  alpha: 1.0,
+};
 const SIZE: usize = 256;
 
 fn mono(white: bool) -> Pixel {
@@ -155,7 +165,7 @@ enum Pattern {
 
 impl Pattern {
   fn cycle(self) -> Pattern {
-    FromPrimitive::from_u8(self as u8 + 1).unwrap_or_else(||FromPrimitive::from_u8(0).unwrap())
+    FromPrimitive::from_u8(self as u8 + 1).unwrap_or_else(|| FromPrimitive::from_u8(0).unwrap())
   }
 
   fn render(self, pixels: &mut [Pixel]) {
@@ -163,14 +173,22 @@ impl Pattern {
     match self {
       Black => pixels.iter_mut().map(|pixel| *pixel = BLACK).count(),
       White => pixels.iter_mut().map(|pixel| *pixel = WHITE).count(),
-      Grey => pixels.iter_mut().enumerate().map(|(i, pixel)| {
-        let y = i / SIZE;
-        *pixel = mono(i % 2 == y % 2);
-      }).count(),
-      Striped => pixels.iter_mut().enumerate().map(|(i, pixel)| {
-        let y = i % SIZE;
-        *pixel = mono(y % 2 == 0);
-      }).count(),
+      Grey => pixels
+        .iter_mut()
+        .enumerate()
+        .map(|(i, pixel)| {
+          let y = i / SIZE;
+          *pixel = mono(i % 2 == y % 2);
+        })
+        .count(),
+      Striped => pixels
+        .iter_mut()
+        .enumerate()
+        .map(|(i, pixel)| {
+          let y = i % SIZE;
+          *pixel = mono(y % 2 == 0);
+        })
+        .count(),
     };
   }
 }
@@ -206,6 +224,8 @@ uniform sampler2D source;
 
 uniform sampler2D samples;
 
+uniform sampler2D frequencies;
+
 vec4 render(float position, float intensity) {
   vec4 src = texture(source, uv);
   if (position < intensity) {
@@ -216,7 +236,7 @@ vec4 render(float position, float intensity) {
 }
 
 void main() {
-  vec4 sample = texture(samples, uv.ts);
+  vec4 sample = uv.y < 0.5 ? texture(samples, uv.ts) : texture(frequencies, uv.ts);
 
   if (uv.x < 0.5) {
     color = render(uv.x * 4 - 1, sample.x);
@@ -229,7 +249,11 @@ void main() {
 
   fn tick(&mut self, _: Duration, events: &[Event]) {
     for event in events {
-      if let Event::Button{button: Button::Action, state: ButtonState::Pressed} = event {
+      if let Event::Button {
+        button: Button::Action,
+        state: ButtonState::Pressed,
+      } = event
+      {
         self.pattern = self.pattern.cycle();
       }
     }

--- a/pxl/src/runtime/common.rs
+++ b/pxl/src/runtime/common.rs
@@ -13,5 +13,6 @@ pub use runtime::{
   glutin::{
     dpi::{LogicalSize, PhysicalSize}, GlContext, GlWindow,
   },
+  rustfft::num_traits::Zero as FftZero, rustfft::{num_complex::Complex, FFTplanner},
   shader_cache::ShaderCache, speaker::Speaker,
 };

--- a/pxl/src/runtime/shader_cache.rs
+++ b/pxl/src/runtime/shader_cache.rs
@@ -72,6 +72,10 @@ impl ShaderCache {
       let sample_uniform = gl::GetUniformLocation(program, zsamples.as_ptr());
       gl::Uniform1i(sample_uniform, 1);
 
+      let zsamples = CString::new("frequencies").unwrap();
+      let sample_uniform = gl::GetUniformLocation(program, zsamples.as_ptr());
+      gl::Uniform1i(sample_uniform, 3);
+
       let zposition = CString::new("position").unwrap();
       let pos_attr = gl::GetAttribLocation(program, zposition.as_ptr());
       gl::EnableVertexAttribArray(pos_attr as GLuint);


### PR DESCRIPTION
Shaders may now access frequency domain data in the `frequencies` texture sampler